### PR TITLE
Fix consistency - store subsets

### DIFF
--- a/briefcase.py
+++ b/briefcase.py
@@ -6,185 +6,328 @@ from enum import Enum
 from pathlib import Path
 from collections import defaultdict
 
-decision = Enum('Decision', ['pi', 'delta', 'un'])
+# Decisions are either for side pi, for side delta, or undecided
+# Pi = child can have dessert
+# Delta = child cannot have dessert# Undecided = ?
+decision = Enum("Decision", ["pi", "delta", "un"])
+
 
 class Factor:
-    def __init__(self, name, polarity='un'):
+    """Class describing a factor which contributes to a decision
+    e.g. factor 1, name = "child ate their dinner", polarity = pi (child can have dessert)
+    """
+
+    def __init__(self, name, polarity="un"):
+        """
+        @param name: name of the given factor
+        @param polarity: the result of the decision (pi/delta/undecided)
+        """
         self.name = name
         self.polarity = polarity
-    
+
     def __eq__(self, other):
-        if type(other) is type(self):        
+        """
+        @param other: second factor, to compare instance factor to
+        @return: override equality return based on factor name and factor polarity
+        """
+        if type(other) is type(self):
             return self.name == other.name and self.polarity == other.polarity
         else:
             return False
 
     def __hash__(self):
-        return hash(self.name+str(self.polarity))
+        """
+        @return: override hash of factor based on factor name and factor polarity
+        """
+        return hash(self.name + str(self.polarity))
+
+    def __str__(self):
+        """
+        @return: String representation of the Factor for human-readable output
+        """
+
+        return f"Factor: {self.name}, Polarity: {self.polarity}"
+
+    def __repr__(self):
+        """
+        @return: String representation of the Factor for recreation
+        """
+
+        return f"Factor('{self.name}', '{self.polarity}')"
+
 
 class Case:
+    """
+    Class describing a case
+    e.g. case 1
+    pi_factors = [name="The child ate their dinner", polarity=pi]
+    delta_factors = [name="The child didn't do their homework", polarity=delta]
+    the decision = pi
+    reason = [name="The child ate their dinner", polarity=pi]
+    """
 
     @classmethod
     def from_dict(cls, dic):
-        # Should do sanity check e.g., that reason is a subset of the winning factors.
-        return cls(frozenset({Factor(f, decision.pi) for f in dic['pi']}), 
-                frozenset({Factor(f, decision.pi) for f in dic['delta']}), 
-                decision[dic['decision']], 
-                frozenset({Factor(f, decision.pi) for f in dic['reason']}))
-    
-    def __init__(self, pi_factors=frozenset(), delta_factors=frozenset(), decision=decision.un, reason=frozenset()):
-        '''I think we can have as a degenerate case a pure decision, that is, one with no factors
+        """
+        @param dic: a dictionary of 'pi', 'delta' and 'reason' factor lists, and a 'decision'
+        @return: An instance of the Case class based on the dic.
+        Converts pi, delta, and reason factor lists to frozensets (immutable sets) of tuples of each factor
+        name and the polarity.
+        """
+        # Convert 'pi', 'delta', and 'reason' lists to frozensets of tuples
+        pi_factors = frozenset((Factor(f, decision.pi) for f in dic["pi"]))
+        # TODO: Change these to correct polarity of factors
+        delta_factors = frozenset((Factor(f, decision.pi) for f in dic["delta"]))
+        decision_value = decision[
+            dic["decision"]
+        ]  # Will throw a Key error if decision not a member of enum
+        reason_factors = frozenset(
+            (Factor(f, decision_value.pi) for f in dic["reason"])
+        )
+        # Determine the winning factors based on the decision polarity
+        winning_factors = pi_factors if decision_value == decision.pi else delta_factors
+        # TODO: Sanity check: Ensure 'reason' is a subset of the winning factors
+        if not reason_factors.issubset(winning_factors):
+            raise ValueError(
+                f"""'reason_factors' is not a subset of the 'winning_factors' with the
+                                 polarity {decision_value}"""
+            )
+        return cls(pi_factors, delta_factors, decision_value, reason_factors)
+
+    def __init__(
+        self,
+        pi_factors=frozenset(),
+        delta_factors=frozenset(),
+        decision=decision.un,
+        reason=frozenset(),
+    ):
+        # TODO: what is nominal typing
+        """I think we can have as a degenerate case a pure decision, that is, one with no factors
         and thus no reasons. Alternatively, we could force all such to be undecided.
-        
+
         If we allow nominal typing, then degenerate cases can be meaninfully different. We might use
         a general rule to express burden of proof, e.g., that we default for the defense.
-        
-        We might want to have an additional typology of cases to allow different burden of proofs for 
-        different sorts of cases, e.g., civil vs. criminal.'''
-        
+
+        We might want to have an additional typology of cases to allow different burden of proofs for
+        different sorts of cases, e.g., civil vs. criminal."""
+
         self.pi_factors = pi_factors
         self.delta_factors = delta_factors
         self.decision = decision
         self.reason = reason
-    
-    def defeated(self): #TODO: make property
+
+    def defeated(self):  # TODO: make property
+        """
+        @return: the factors which were defeated by the decision e.g. for a decision of polarity pi, the delta factors
+        """
+        # TODO: Why not just make pi_factors always the winning set and delta always the defeated set at initialisation,
+        #       that way you don't need functions like this?
         if self.decision == decision.pi:
             return self.delta_factors
         elif self.decision == decision.delta:
             return self.pi_factors
         else:
-            return set() #TODO: Throw error?
-    
+            return (
+                set()
+            )  # TODO: Throw error? Already happens further up, ths code would never be reached
+
     def relevant_diff_from(self, other_case):
         """All factors have a singleton dimension and thus
         any individual factor"""
+        # TODO: Look up what relevant differences are again
         if self.decision == other_case.decision:
             pass
+
+    def __str__(self):
+        """
+        @return: String representation of the Case for human-readable output
+        """
+
+        pi_factors_str = [str(factor) for factor in self.pi_factors]
+        delta_factors_str = [str(factor) for factor in self.delta_factors]
+        decision_str = f"Decision: {self.decision.name}"
+        reason_str = [str(factor) for factor in self.reason]
+        return (
+            f"Case:\n  Pi Factors: {', '.join(pi_factors_str)}\n  Delta Factors: {', '.join(delta_factors_str)}\n  "
+            f"{decision_str}\n  Reasons: {', '.join(reason_str)}"
+        )
+
+    def __repr__(self):
+        """
+        @return: String representation of the Case for recreation
+        """
+        pi_factors_repr = [repr(factor) for factor in self.pi_factors]
+        delta_factors_repr = [repr(factor) for factor in self.delta_factors]
+        decision_repr = (
+            f"Decision.{self.decision.name}"  # Assuming 'decision' is an enum
+        )
+        reason_repr = [repr(factor) for factor in self.reason]
+        return f"""Case(Pi Factors: {pi_factors_repr}, Delta Factors: {delta_factors_repr}, {
+        decision_repr}, Reasons: {reason_repr})"""
+
+
 class PriorityOrder:
+    """
+    Orders reasons and factors in a dictionary.
+    Key is a frozenset of the stronger factors, value is a frozenset of the weaker factors.
+    """
+
     def __init__(self):
+        # default-dict does not error when referencing a key which doesn't exist
         self.order = defaultdict(set)
 
     def is_consistent(self):
-        for U, Vs in list(self.order.items()): #Honestly no idea! What am I changing below?! Copy doesn't work!
-            for V in Vs:
+        """
+        @return : True/False if current ordering is consistent
+        """
+        # list() modifies dictionary safely, it performs a deep copy like .deepcopy()
+        # whereas .copy() is a shallow copy of the dict - still references same objects
+        for U, Vs in list(self.order.items()):
+            for V in Vs:  # loop through defeated items (Vs)
                 # We know U > V. Check for reverse!
-                for u in self.order[V]:
-                    if U.issubset(u): #i.e., U < u, since then U < V since  u < V and subset rule
+                for u in self.order[V]:  # check defeated items where v was the winner
+                    if U.issubset(
+                        u
+                    ):  # i.e., U < u, since then U < V since  u < V and subset rule
                         return False
         return True
-    
+
     def is_consistent_with(self, case):
-        assert self.is_consistent() #TODO: is this what we want?
-        
+        """
+        @param case: a new case
+        @return: True/False if current casebase ordering would be consistent with the new case added
+        """
+        assert self.is_consistent()  # TODO: is this what we want?
+
         reason = case.reason
         defeated = case.defeated()
         # It's only one step, so we don't have to chase long cycles.
+        # Check every defeated value for which the winning key is contained within the defeated factors of the case
+        # simple case:
+        # winning old: p1,
+        # defeated old: d1, d2
+        # defeated new: p1, p2
+        # reason new: d1
         for U in [self.order[r] for r in self.order.keys() if r.issubset(defeated)]:
-            for u in U:
-                if reason.issubset(u):
+            for u in U:  # loop through each defeated reason
+                if reason.issubset(u):  # oh no a cycle!
                     return False
         return True
 
     def add_pair_as_appropriate(self, r1, r2):
+        """
+        @param r1: first reason
+        @param r2: second reason
+        Adds pairs of reasons to the priority order dictionary, where stronger reason : weaker reason
+        within the dictionary 'order'
+        """
+        # TODO: How does this work with the case where the reasons are of opposite polarity? You wouldn't be checking
+        #  subsets then, but be checking if the premise/reason is contained within the other reason,
+        #  then clearly U is at least as strong as V
         if r1 == r2:
             return
-        if r1.issubset(r2):
+        if r1.issubset(r2):  # then r2 is at least as strong as r1
             # Potentially a bit slow for large reasons? could check for polarity first.
             self.order[r2].add(r1)
-            #ds has to be of opposite polarity thus disjoint from the reason
+            # ds has to be of opposite polarity thus disjoint from the reason
+            # TODO: what does this mean?
         elif r2.issubset(r1):
             self.order[r1].add(r2)
- 
+
     def unsafe_add_cases(self, cases):
         for c in cases:
-            self.unsafe_add_case(c)    
-            
+            self.unsafe_add_case(c)
+
     def unsafe_add_case(self, case):
-        '''Adds the decision with no safety checks.'''        
-        self.order[case.reason].add(case.defeated())  
+        """
+        @param case: the new case to be added to the priority order
+        Adds a new case to order dict with no safety checks.
+        """
+
+        # case 1: we know the winning reason is at least as strong as the defeated factors, since it won
+        self.order[case.reason].add(case.defeated())
         for r, ds in list(self.order.items()):
+            # case 2: check if winning reason is stronger than other winning reasons in the dictionary
             self.add_pair_as_appropriate(case.reason, r)
             # Because we don't do a polarity check, we have to test *all* ds...boo)
             for d in ds:
+                # case 3: check if winning reason is stronger than other defeated reasons in the dictionary
                 self.add_pair_as_appropriate(case.reason, d)
-    
+
     def newly_inconsistent_with(self, case):
         pass
-           
+
     def inconsistent_pairs(self):
         pass
-    
-class NXPriorityOrder:
-    def __init__(self):
-        self.order = nx.DiGraph()
-    
-    def is_consistent(self):
-        pass
-    
-    def is_consistent_with(self, case):
-        reason = case.reason
-        defeated = case.defeated()
-    
-    def newly_inconsistent_with(self, case):
-        pass
-    
-    def add_case(self, case):
-        '''Adds the decision with no safety checks.'''
-        reason = case.reason
-        defeated = case.defeated()
-        self.order.add_edge(reason, defeated(), case=case) #TODO: add attribute
-        # A reason is *at least as strong* than any subset of the reason
-        for n in self.order.nodes:
-            if n.issubset(reason):
-                self.order.add_edge(reason, n, type="superset")
-            if n.issubset(defeated):
-                self.order.add_edge(defeated, n, type="superset")
-        
-    def inconsistent_pairs(self):
-        pass
+
 
 class CaseBase:
     def __init__(self, caselist=[]):
         self.cases = caselist
         self.order = PriorityOrder()
         self.order.unsafe_add_cases(self.cases)
-    
+
     def add_case(self, case):
         self.cases.append(case)
         self.order.unsafe_add_case(case)
-        
+
     def is_consistent(self):
         return self.order.is_consistent()
-    
+
     def is_consistent_with(self, case):
         return self.order.is_consistent_with(case)
-                
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='A tool to do precedential case reasoning.')
-    parser.add_argument('-c', '--casebase', type=Path,
-                    help='a file containing a case base')
-    parser.add_argument('-n', '--newcase', type=Path, 
-                    help='file containing a case not in the base')
-    parser.add_argument('-a', '--action', type=str, default='test', 
-                        help='indicates the preferred action: "check" (default), or "add" (if consistent) or "test" (default) for run tests')
+    def __str__(self):
+        """
+        @return: String representation of the CaseBase for human-readable output
+        """
+        cases_str = [str(case) for case in self.cases]
+        cases_formatted = "\n\n".join(cases_str)
+        return f"CaseBase:\n{cases_formatted}"
+
+    def __repr__(self):
+        """
+        @return: String representation of the CaseBase for recreation
+        """
+        cases_repr = [repr(case) for case in self.cases]
+        return f"CaseBase({cases_repr})"
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="A tool to do precedential case reasoning."
+    )
+    parser.add_argument(
+        "-c", "--casebase", type=Path, help="a file containing a case base"
+    )
+    parser.add_argument(
+        "-n", "--newcase", type=Path, help="file containing a case not in the base"
+    )
+    parser.add_argument(
+        "-a",
+        "--action",
+        type=str,
+        default="test",
+        help='indicates the preferred action: "check" (default), or "add" (if consistent) or "test" (default) for run tests',
+    )
 
     args = parser.parse_args()
-    
+
     import doctest
-    doctest.testfile('example_tests.txt')
-    
-    #cases = list()
-    #for c in yaml.safe_load(args.casebase.read_text()):
-        #cases.append(Case.from_dict(c))
-    #cb = CaseBase(cases)
-    #c = yaml.safe_load('''name: case3
-#pi: [p1,p3,p7]
-#delta: [d5, d2, d3]
-#decision: pi
-#reason: [p1,p3,p7]''')
-    #tc = Case.from_dict(c)
-    #print("CB consistent?", cb.order.is_consistent())
-    #print("Consistent with?", cb.is_consistent_with(tc))
-    #cb.add_case(tc)
-    #print("Consistent if we add it?", cb.order.is_consistent())
+
+    doctest.testfile("example_tests.txt")
+
+    # cases = list()
+    # for c in yaml.safe_load(args.casebase.read_text()):
+    # cases.append(Case.from_dict(c))
+    # cb = CaseBase(cases)
+    # c = yaml.safe_load('''name: case3
+# pi: [p1,p3,p7]
+# delta: [d5, d2, d3]
+# decision: pi
+# reason: [p1,p3,p7]''')
+# tc = Case.from_dict(c)
+# print("CB consistent?", cb.order.is_consistent())
+# print("Consistent with?", cb.is_consistent_with(tc))
+# cb.add_case(tc)
+# print("Consistent if we add it?", cb.order.is_consistent())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyyaml
 networkx
 textual
+pytest

--- a/test_case_base.yaml
+++ b/test_case_base.yaml
@@ -5,6 +5,20 @@ one_case:
    decision: pi
    reason: [p1]
 
+# error cases
+error_case_bad_decision:
+   pi: [p1]
+   delta: [d1]
+   decision: pies
+   reason: [p1]
+
+error_case_bad_reason:
+   pi: [p1]
+   delta: [d1]
+   decision: pi
+   reason: [p3]
+
+
 # simple test cases
 simple_small:
 -

--- a/test_case_base.yaml
+++ b/test_case_base.yaml
@@ -1,12 +1,90 @@
+# base case
+one_case:
+   pi: [p1]
+   delta: [d1]
+   decision: pi
+   reason: [p1]
+
+# simple test cases
+simple_small:
 -
-   name: case1
+   pi: [p1]
+   delta: [d1]
+   decision: pi
+   reason: [p1]
+- # inconsistent to case 1 - different polarity, same factors
+   pi: [p1]
+   delta: [d1]
+   decision: delta
+   reason: [d1]
+
+# big test cases
+simple_big: # simple test case, one factor per side, reason = winning factor
+-
    pi: [p1,p2,p3,p4]
    delta: [d1, d2, d3]
    decision: pi
    reason: [p1, p3]
 -
-   name: case2
    pi: [p1,p3,p7]
    delta: [d5, d2, d3]
    decision: delta
    reason: [d5, d2, d3]
+- # inconsistent to case 1 - different polarity, same factors
+   pi: [p1,p3,p7]
+   delta: [d5, d2, d3]
+   decision: pi
+   reason: [p1]
+
+# distractors, extra stuff but no subset reasoning
+distractor_small:
+-
+   pi: [p1, p2]
+   delta: [d1]
+   decision: pi
+   reason: [p1]
+-
+   pi: [p1]
+   delta: [d2, d3]
+   decision: delta
+   reason: [d2]
+- # inconsistent with case 1 - same case with distractors, different decisions
+   pi: [p1]
+   delta: [d1, d3]
+   decision: delta
+   reason: [d1]
+
+# subset reasoning
+subset_small:
+-
+   pi: [p1, p2]
+   delta: [d1, d3, d4]
+   decision: pi
+   reason: [p1]
+-
+   pi: [p1]
+   delta: [d2, d3]
+   decision: delta
+   reason: [d2]
+- # inconsistent with case 1 - cycle - p1 defeats d1, d3 - d1 defeats p1
+   pi: [p1]
+   delta: [d1, d3]
+   decision: delta
+   reason: [d1]
+
+subset_big:
+-
+   pi: [p1, p2, p3, p4]
+   delta: [d1, d3, d4]
+   decision: pi
+   reason: [p1, p3]
+-
+   pi: [p1]
+   delta: [d2, d3]
+   decision: delta
+   reason: [d2]
+- # inconsistent with case 1
+   pi: [p1, p3, p6, p7]
+   delta: [d1, d2, d3, d4]
+   decision: delta
+   reason: [d1, d3]

--- a/test_case_base.yaml
+++ b/test_case_base.yaml
@@ -93,8 +93,114 @@ subset_big:
    decision: pi
    reason: [p1, p3]
 
+-
+   pi: [p1]
+   delta: [d2, d3]
+   decision: delta
+   reason: [d2]
+
 - # inconsistent with case 1
    pi: [p1, p3, p5, p6]
    delta: [d1, d2, d3, d4]
    decision: delta
    reason: [d1, d3]
+
+# replicate when multiple entries will be in the self.order
+# dict for the same reason
+multi_defeated_small:
+-
+   pi: [p1]
+   delta: [d1]
+   decision: pi
+   reason: [p1]
+
+-
+   pi: [p1]
+   delta: [d2]
+   decision: pi
+   reason: [p1]
+
+- # inconsistent with case 2, same factors, different polarity
+   pi: [p1]
+   delta: [d2]
+   decision: delta
+   reason: [d2]
+
+multi_defeated_big:
+-
+   pi: [p1, p2, p3, p4]
+   delta: [d1, d3, d4]
+   decision: pi
+   reason: [p1, p3]
+
+-
+   pi: [p1, p3, p5]
+   delta: [d2, d3]
+   decision: pi
+   reason: [p1, p3]
+
+- # inconsistent with case 1, subset
+   pi: [p1, p2, p3, p5]
+   delta: [d1, d3]
+   decision: delta
+   reason: [d1, d3]
+
+mega_case_10:
+-
+   pi: [p1]
+   delta: [d1]
+   decision: pi
+   reason: [p1]
+
+-
+   pi: [p2]
+   delta: [d2]
+   decision: delta
+   reason: [d2]
+
+-
+   pi: [p1]
+   delta: [d3]
+   decision: pi
+   reason: [p1]
+
+-
+   pi: [p1, p2]
+   delta: [d4]
+   decision: delta
+   reason: [d4]
+
+-
+   pi: [p1, p2, p5]
+   delta: [d4]
+   decision: pi
+   reason: [p2, p5]
+
+-
+   pi: [p10, p1, p2, p3, p4, p5, p6, p7, p8, p9]
+   delta: [d10, d1, d2, d3, d4, d5, d6, d7, d8, d9]
+   decision: delta
+   reason: [d10]
+-
+   pi: [p1, p2, p3]
+   delta: [d1, d5]
+   decision: pi
+   reason: [p1]
+
+-
+   pi: [p8]
+   delta: [d8, d10]
+   decision: delta
+   reason: [d10]
+
+-
+   pi: [p1, p9, p8, p5]
+   delta: [d9, d3, d4]
+   decision: delta
+   reason: [d4, d3]
+
+- # inconsistent case
+   pi: [p1, p2]
+   delta: [d10, d4]
+   decision: pi
+   reason: [p1]

--- a/test_case_base.yaml
+++ b/test_case_base.yaml
@@ -204,3 +204,21 @@ mega_case_10:
    delta: [d10, d4]
    decision: pi
    reason: [p1]
+
+combined_factors:
+-
+   pi: [p1, p3, p5]
+   delta: [d1, d2, d3]
+   decision: pi
+   reason: [p1]
+-
+   pi: [p2]
+   delta: [d1, d2]
+   decision: delta
+   reason: [d1]
+- # inconsistent with case 1
+   pi: [p1, p2]
+   delta: [d1, d2, d3]
+   decision: delta
+   reason: [d1, d3]
+

--- a/test_case_base.yaml
+++ b/test_case_base.yaml
@@ -92,13 +92,9 @@ subset_big:
    delta: [d1, d3, d4]
    decision: pi
    reason: [p1, p3]
--
-   pi: [p1]
-   delta: [d2, d3]
-   decision: delta
-   reason: [d2]
+
 - # inconsistent with case 1
-   pi: [p1, p3, p6, p7]
+   pi: [p1, p3, p5, p6]
    delta: [d1, d2, d3, d4]
    decision: delta
    reason: [d1, d3]

--- a/test_consistency.py
+++ b/test_consistency.py
@@ -12,6 +12,15 @@ def test_cases():
         return yaml.safe_load(f)
 
 
+@pytest.mark.parametrize(
+    "test_name, error_type",
+    [("error_case_bad_decision", KeyError), ("error_case_bad_reason", ValueError)],
+)
+def test_errors_case_from_dict(test_cases, test_name, error_type):
+    with pytest.raises(error_type):
+        Case.from_dict(test_cases[test_name])
+
+
 def test_base_case_consistency(test_cases):
     cb1 = CaseBase([])  # no cases
     assert cb1.is_consistent()
@@ -35,4 +44,5 @@ def test_consistency(test_cases, test_case_name):
 
     assert not cb1.is_consistent_with(inconsistent_case)
     cb1.add_case(inconsistent_case)
+    print("\n\n here")
     assert not cb1.is_consistent()

--- a/test_consistency.py
+++ b/test_consistency.py
@@ -1,7 +1,7 @@
 import pytest
 import yaml
 from pathlib import Path
-from briefcase import Case, CaseBase
+from briefcase import Case, CaseBase, PriorityOrder
 
 
 # Define a fixture to load test cases from the YAML file
@@ -41,6 +41,7 @@ def test_base_case_consistency(test_cases):
         "multi_defeated_small",
         "multi_defeated_big",
         "mega_case_10",
+        "combined_factors"
     ],
 )
 def test_consistency(test_cases, test_case_name):
@@ -55,3 +56,24 @@ def test_consistency(test_cases, test_case_name):
     cb1.add_case(inconsistent_case)
 
     assert not cb1.is_consistent()
+
+
+# test add order with subsets references the same object to the order
+@pytest.mark.parametrize(
+    "test_case_name",
+    [
+        "simple_small",
+        "simple_big"
+    ],
+)
+def test_add_order_with_subsets_id(test_cases, test_case_name):
+    cs = test_cases[test_case_name]
+    case = Case.from_dict(cs[0])  # get first case
+    order = PriorityOrder()  # blank priority order
+    order.add_order_with_subsets(case.reason, case.defeated())  # add one element
+    # check if items added, and that the id is the same id
+    assert any(case.reason is obj for obj in order.order.keys())
+    assert any(case.reason is obj for subset in order.subsets.values() for obj in subset)
+
+
+

--- a/test_consistency.py
+++ b/test_consistency.py
@@ -32,7 +32,16 @@ def test_base_case_consistency(test_cases):
 # Define the tests using the loaded test cases
 @pytest.mark.parametrize(
     "test_case_name",
-    ["simple_small", "simple_big", "distractor_small", "subset_small", "subset_big"],
+    [
+        "simple_small",
+        "simple_big",
+        "distractor_small",
+        "subset_small",
+        "subset_big",
+        "multi_defeated_small",
+        "multi_defeated_big",
+        "mega_case_10",
+    ],
 )
 def test_consistency(test_cases, test_case_name):
     cs = test_cases[test_case_name]

--- a/test_consistency.py
+++ b/test_consistency.py
@@ -44,5 +44,5 @@ def test_consistency(test_cases, test_case_name):
 
     assert not cb1.is_consistent_with(inconsistent_case)
     cb1.add_case(inconsistent_case)
-    print("\n\n here")
+
     assert not cb1.is_consistent()

--- a/test_consistency.py
+++ b/test_consistency.py
@@ -1,0 +1,38 @@
+import pytest
+import yaml
+from pathlib import Path
+from briefcase import Case, CaseBase
+
+
+# Define a fixture to load test cases from the YAML file
+@pytest.fixture
+def test_cases():
+    test_cases_file = Path("test_case_base.yaml")
+    with test_cases_file.open("r") as f:
+        return yaml.safe_load(f)
+
+
+def test_base_case_consistency(test_cases):
+    cb1 = CaseBase([])  # no cases
+    assert cb1.is_consistent()
+    case = Case.from_dict(test_cases["one_case"])  # one case
+    cb1.add_case(case)
+    assert cb1.is_consistent()
+
+
+# Define the tests using the loaded test cases
+@pytest.mark.parametrize(
+    "test_case_name",
+    ["simple_small", "simple_big", "distractor_small", "subset_small", "subset_big"],
+)
+def test_consistency(test_cases, test_case_name):
+    cs = test_cases[test_case_name]
+    cases = [Case.from_dict(c) for c in cs[:-1]]  # don't include last case
+    cb1 = CaseBase(cases)
+    assert cb1.is_consistent()
+
+    inconsistent_case = Case.from_dict(cs[-1])
+
+    assert not cb1.is_consistent_with(inconsistent_case)
+    cb1.add_case(inconsistent_case)
+    assert not cb1.is_consistent()


### PR DESCRIPTION
1. Annotates/docstrings code, and adds str/repr functions (to help me understand)
2. Refactors test suite to use Pytest, though the old doctest version remains still
3. Fixes `is_consistent` using the simplest method ~ O(n^2 * m) I think, where n is the number of items in `self.order`, and where m is the number of items in each defeated value bucket. Might be worth structuring `self.order` in a different way - graphs? I will have a think.  I'm also not completely sure this is correct. But it passes the new test cases I have written, and the previous version definitely is not correct.

